### PR TITLE
Fix start/end dates for quarters that weren't on a standard 3 month boundary

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# http://editorconfig.org
+root = true
+
+[*.js]
+indent_style = tab
+

--- a/moment-fquarter.js
+++ b/moment-fquarter.js
@@ -8,30 +8,31 @@
 
 	function onload(moment) {
 		moment.fn.fquarter = function (startMonth) {
+			startMonth = startMonth || 4; // default is April
 			var thisDate = this.clone();
 			var initial = thisDate.local()._quarter || "Q";
-			var result = {}, adjustedDate, nextYear = null;
-			startMonth = startMonth || 4; // default is April
-			var originalDate = this.clone();
+			var result = {};
+			var adjustedDate = thisDate;
+			var nextYear = null;
+			var fiscalCalendarIndex = buildFiscalCalendar(startMonth).indexOf(this.month());
+			var monthsIntoQuarter = fiscalCalendarIndex % 3;
+			var startOfQuarter = this.clone().startOf("month").subtract(monthsIntoQuarter, "months");
 
 			if (startMonth > 1) {
 				adjustedDate = thisDate.subtract(startMonth - 1, "months");
 				nextYear = adjustedDate.clone().add(1, "years");
-			} else {
-				adjustedDate = thisDate;
 			}
+
 			if (startMonth < 0) {
 				adjustedDate = thisDate.subtract(12 + startMonth, "month").add(1, "year");
 				nextYear = adjustedDate.clone().add(1, "year");
-			} else {
-				adjustedDate = thisDate;
 			}
 
 			result.quarter = Math.ceil((adjustedDate.month() + 1.0) / 3.0);
 			result.year = adjustedDate.year();
 			result.nextYear = (nextYear) ? nextYear.year() : nextYear;
-			result.start = originalDate.set("date", 1).subtract((originalDate.month()+12)%3, "months").format("YYYY-MM-DD");
-			result.end =   originalDate.set("date", 1).subtract((originalDate.month()+12)%3, "months").add(3, "months").subtract(1, "day").format("YYYY-MM-DD");
+			result.start = startOfQuarter.format("YYYY-MM-DD");
+			result.end = startOfQuarter.add(3, "months").subtract(1, 'day').format("YYYY-MM-DD");
 
 			result.toString = function () {
 				var str = initial + result.quarter + " " + result.year;
@@ -42,6 +43,23 @@
 		};
 
 		return moment;
+	}
+
+	function buildFiscalCalendar(startMonth) {
+		if (startMonth < 0) {
+			startMonth = 13 + startMonth;
+		}
+
+		startMonth--;
+		var months = [];
+
+		for (var i = 0; i < 12; i++) {
+			months.push(startMonth);
+			startMonth++;
+			if (startMonth > 11) startMonth = 0;
+		}
+
+		return months;
 	}
 
 	if (typeof define === "function" && define.amd) {

--- a/test/fquarterSpec.coffee
+++ b/test/fquarterSpec.coffee
@@ -76,40 +76,40 @@ describe "Calendar quarters", ->
 
 describe "Academic quarters", ->
   it "Jan is Q2", ->
-    expect(moment("2013-01-01").fquarter(9)).toEqual({quarter: 2, year: 2012, nextYear: 2013, start: "2013-01-01", end: "2013-03-31"})
+    expect(moment("2013-01-01").fquarter(9)).toEqual({quarter: 2, year: 2012, nextYear: 2013, start: "2012-12-01", end: "2013-02-28"})
     expect(moment("2013-01-01").fquarter(9).toString()).toEqual("Q2 2012/13")
   it "Feb is Q2", ->
-    expect(moment("2013-02-01").fquarter(9)).toEqual({quarter: 2, year: 2012, nextYear: 2013, start: "2013-01-01", end: "2013-03-31"})
+    expect(moment("2013-02-01").fquarter(9)).toEqual({quarter: 2, year: 2012, nextYear: 2013, start: "2012-12-01", end: "2013-02-28"})
     expect(moment("2013-02-01").fquarter(9).toString()).toEqual("Q2 2012/13")
   it "Mar is Q3", ->
-    expect(moment("2013-03-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-01-01", end: "2013-03-31"})
+    expect(moment("2013-03-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-03-01", end: "2013-05-31"})
     expect(moment("2013-03-01").fquarter(9).toString()).toEqual("Q3 2012/13")
   it "Apr is Q3", ->
-    expect(moment("2013-04-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-04-01", end: "2013-06-30"})
+    expect(moment("2013-04-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-03-01", end: "2013-05-31"})
     expect(moment("2013-04-01").fquarter(9).toString()).toEqual("Q3 2012/13")
   it "May is Q3", ->
-    expect(moment("2013-05-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-04-01", end: "2013-06-30"})
+    expect(moment("2013-05-01").fquarter(9)).toEqual({quarter: 3, year: 2012, nextYear: 2013, start: "2013-03-01", end: "2013-05-31"})
     expect(moment("2013-05-01").fquarter(9).toString()).toEqual("Q3 2012/13")
   it "Jun is Q4", ->
-    expect(moment("2013-06-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-04-01", end: "2013-06-30"})
+    expect(moment("2013-06-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-06-01", end: "2013-08-31"})
     expect(moment("2013-06-01").fquarter(9).toString()).toEqual("Q4 2012/13")
   it "Jul is Q4", ->
-    expect(moment("2013-07-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-07-01", end: "2013-09-30"})
+    expect(moment("2013-07-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-06-01", end: "2013-08-31"})
     expect(moment("2013-07-01").fquarter(9).toString()).toEqual("Q4 2012/13")
   it "Aug is Q4", ->
-    expect(moment("2013-08-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-07-01", end: "2013-09-30"})
+    expect(moment("2013-08-01").fquarter(9)).toEqual({quarter: 4, year: 2012, nextYear: 2013, start: "2013-06-01", end: "2013-08-31"})
     expect(moment("2013-08-01").fquarter(9).toString()).toEqual("Q4 2012/13")
   it "Sep is Q1", ->
-    expect(moment("2013-09-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-07-01", end: "2013-09-30"})
+    expect(moment("2013-09-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-09-01", end: "2013-11-30"})
     expect(moment("2013-09-01").fquarter(9).toString()).toEqual("Q1 2013/14")
   it "Oct is Q1", ->
-    expect(moment("2013-10-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-10-01", end: "2013-12-31"})
+    expect(moment("2013-10-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-09-01", end: "2013-11-30"})
     expect(moment("2013-10-01").fquarter(9).toString()).toEqual("Q1 2013/14")
   it "Nov is Q1", ->
-    expect(moment("2013-11-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-10-01", end: "2013-12-31"})
+    expect(moment("2013-11-01").fquarter(9)).toEqual({quarter: 1, year: 2013, nextYear: 2014, start: "2013-09-01", end: "2013-11-30"})
     expect(moment("2013-11-01").fquarter(9).toString()).toEqual("Q1 2013/14")
   it "Dec is Q2", ->
-    expect(moment("2013-12-01").fquarter(9)).toEqual({quarter: 2, year: 2013, nextYear: 2014, start: "2013-10-01", end: "2013-12-31"})
+    expect(moment("2013-12-01").fquarter(9)).toEqual({quarter: 2, year: 2013, nextYear: 2014, start: "2013-12-01", end: "2014-02-28"})
     expect(moment("2013-12-01").fquarter(9).toString()).toEqual("Q2 2013/14")
 
 describe "Backwards Fiscal Year quarters", ->


### PR DESCRIPTION
When the start of the fiscal year wasn't 1, 4, 7 or 9 then the `start` and `end` dates weren't correct...assuming that meant start and end of the fiscal quarter. This fixes that.
